### PR TITLE
T120 save html button

### DIFF
--- a/app/controllers/user/resumes_controller.rb
+++ b/app/controllers/user/resumes_controller.rb
@@ -1,5 +1,10 @@
 class User::ResumesController < ApplicationController
   layout "pdf", only: [:download, :preview_download]
+  layout "preview_layout", only: :preview
+  layout false, only: :save_html
+  # layout 'preview_layout', only: :save_html
+
+
 
   def index
     @resumes = Resume.all.order(created_at: :DESC)
@@ -43,6 +48,7 @@ class User::ResumesController < ApplicationController
 
   # 接受web发过来的编辑好的html数据，处理（如保存），之后redirect到显示这个html的pdf
   def relay
+
     @resume = Resume.find(params[:resume_id])
     @resume_html = resume_html_for_resume(@resume)
     @resume_html.content = params[:content]
@@ -50,11 +56,17 @@ class User::ResumesController < ApplicationController
     redirect_to user_resume_preview_path(@resume, format: :pdf)
   end
 
+  def save_html
+    @resume = Resume.find(params[:resume_id])
+    @resume_html = resume_html_for_resume(@resume)
+    @resume_html.content = params[:content]
+    @resume_html.save
+  end
+
 
   def preview
-    # render layout: "preview_layout", locals: { resume: Resume.find(params[:resume_id]) }
+    
     @resume = Resume.find(params[:resume_id])
-    # binding.pry
     respond_to do |format|
       format.html
       format.pdf do

--- a/app/controllers/user/resumes_controller.rb
+++ b/app/controllers/user/resumes_controller.rb
@@ -61,6 +61,7 @@ class User::ResumesController < ApplicationController
     @resume_html = resume_html_for_resume(@resume)
     @resume_html.content = params[:content]
     @resume_html.save
+    # flash[:notice] = 'saved'
   end
 
 

--- a/app/views/layouts/preview_layout.html.erb
+++ b/app/views/layouts/preview_layout.html.erb
@@ -1,8 +1,12 @@
 <!doctype html>
 <html>
 <head>
+
   <meta charset='utf-8' />
   <%= wicked_pdf_stylesheet_link_tag "application" -%>
+  <%= csrf_meta_tags %>
+  <%#= wicked_pdf_stylesheet_link_tag "pdf" -%>
+  <%#= wicked_pdf_javascript_include_tag "number_pages" %>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
 

--- a/app/views/user/resumes/_resume_content.html.erb
+++ b/app/views/user/resumes/_resume_content.html.erb
@@ -91,8 +91,10 @@
 					<p><%= resume.past_project_title1 %></p>
 					<p><%= resume.past_project_description1 %></p>
 					<p>
+						<%# binding.pry %>
+
 						<% if resume.past_project_image1.present? %>
-						<%= image_tag(resume.past_project_image1.thumb.url) %>
+						<%= wicked_pdf_image_tag(resume.past_project_image1.thumb.url) %>
 						<% else %>
 						<% end %>
 					</p>

--- a/app/views/user/resumes/preview.html.erb
+++ b/app/views/user/resumes/preview.html.erb
@@ -1,4 +1,5 @@
 <input type="hidden" id="refresh" value="no">
+<div id="notice"></div>
 
 <%= render "common/progress_bar" %>
 
@@ -51,6 +52,7 @@
       	success: function(result){
       		$('#cv').html(result);
       		// 加入提示的特效
+      		// $("#notice").html("<%= flash[:notice] %>");
       	}
       });
       return false;

--- a/app/views/user/resumes/preview.html.erb
+++ b/app/views/user/resumes/preview.html.erb
@@ -1,39 +1,61 @@
+<input type="hidden" id="refresh" value="no">
+
 <%= render "common/progress_bar" %>
 
 <div class="container" style="text-align:center;">
-	<i style="font-size:25px">在下载之前，可以点击页面任何地方进行最终格式调整</i>
+	<i style="font-size:25px">在下载之前，可以点击页面任何地方进行最终格式调整</i><br><br>
+	<%= link_to "保存", "#", class: "btn btn-primary", id: "save" %>
 </div>
+	
+	<% if @resume.resume_html.present? && @resume.resume_html.content.present? %>
+		<div id="froala-editor">
+			<div id="cv" class="instaFade">
+				<%= @resume.resume_html.content.html_safe %>
+			</div>
+		</div>
+	<% else %>
 		<%= render partial: "resume_content", locals: { resume: @resume } %>
+	<% end %>
 	<a href="#" class="col-md-4 col-md-offset-4 btn btn-primary" id="print">生成并下载PDF格式简历</a>
-<%#= link_to "查看pdf", user_resume_preview_path(@resume, format: :pdf), class: "btn btn-primary" %>
+	
 
 
 <br><br><br><br><br><br>
 
 
 <script type="text/javascript">
+
+	$(document).ready(function(e) {
+		var $input = $('#refresh');
+		$input.val() == 'yes' ? location.reload(true) : $input.val('yes');
+	});
+
+
+
 	$('#print').click(function(event) {
-      // window.print();
-      // return false;
-
-      // PrintElem("content");
-      // alert($('#content').html());
-
       event.preventDefault();
-
-      // $.ajax('preview.pdf', {
-      	// data: {content: $('#cv').html()},
-
-      // });
-
       $.ajax({
       	url: '<%= user_resume_relay_path(@resume) %>',
       	type: 'post',
       	data: { content: $('#cv').html() }
-
       });
       return false;
-  });
+  	});
+
+  	$('#save').click(function(event) {
+      event.preventDefault();
+      $.ajax({
+      	url: '<%= user_resume_save_html_path(@resume) %>',
+      	type: 'get',
+      	data: { content: $('#cv').html() },
+      	success: function(result){
+      		$('#cv').html(result);
+      		// 加入提示的特效
+      	}
+      });
+      return false;
+  	});
+
 
 	$(function() {
 		$('div#froala-editor').froalaEditor({
@@ -44,26 +66,5 @@
 
 		})
 	});
-
-	// function PrintElem(elem) {
-	// 	var mywindow = window.open('', 'PRINT', 'height=400,width=600');
-
-	// 	mywindow.document.write('<html><head><title>' + document.title  + '</title>');
-	// 	mywindow.document.write('<link rel="stylesheet" href="application.css" type="text/css" />');
-	// 	mywindow.document.write('</head><body >');
-	// 	mywindow.document.write('<h1>' + document.title  + '</h1>');
-	// 	mywindow.document.write(document.getElementById(elem).innerHTML);
-	// 	mywindow.document.write('</body></html>');
-
- //        // mywindow.document.close(); // necessary for IE >= 10
- //        mywindow.focus(); // necessary for IE >= 10*/
-
- //        mywindow.print();
- //        // mywindow.close();
-
- //        return true;
- //    }
-
-
 
 </script>

--- a/app/views/user/resumes/preview.pdf.erb
+++ b/app/views/user/resumes/preview.pdf.erb
@@ -1,2 +1,3 @@
 
-  <%= @resume.resume_html.content.html_safe %>
+<%= @resume.resume_html.content.html_safe %>
+

--- a/app/views/user/resumes/save_html.html.erb
+++ b/app/views/user/resumes/save_html.html.erb
@@ -1,0 +1,1 @@
+<%= @resume_html.content.html_safe %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
     resources :resumes do
     	get :preview
       post :relay
+      get :save_html
       # 分页
       collection do
         get :page1


### PR DESCRIPTION
1. 本地测试，pdf中显示不了用carrierwave上传的图片，因为wicked_pdf不支持image_tag这种相对路径的图片，而浏览器不支持显示用绝对路径指示的图片。需要上传到heroku上试一下，目前尽量用preview页面的图片插入
2. 在preview页面加入了保存按钮，点击之后会将当前的html发送给后端，编辑区域也会局部刷新
3. 在preview页面点击查看pdf，之后用浏览器的后退键返回preview页面时加入自动刷新的功能，与后端同步了最新的显示内容